### PR TITLE
Added regex for typical Cisco interface numbering

### DIFF
--- a/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
+++ b/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
@@ -9,16 +9,16 @@ digraph G {
     node  [style="rounded,filled,bold", shape=box, width=1.3, fontname="Arial"];
     edge [fontsize=10]; 
     {% set already_done = [] %}
-    {% for host in hostvars %}
-      {% if 'napalm_lldp_neighbors' in hostvars[host]['ansible_facts'] %}
-        {% set fqdn = hostvars[host]['ansible_facts']['napalm_fqdn'] %}
-        {% set lldp_data = hostvars[host]['ansible_facts']['napalm_lldp_neighbors'] %}
-          {% for interface in lldp_data %}
-            {% if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
-              "{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }}"];
-            {% endif %}
-            {{ already_done.append( { fqdn : interface |lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
-          {% endfor %}
-      {% endif %}
+    {%   for host in hostvars %}
+    {%     if 'napalm_lldp_neighbors' in hostvars[host]['ansible_facts'] %}
+    {%     set fqdn = hostvars[host]['ansible_facts']['napalm_fqdn'] %}
+    {%     set lldp_data = hostvars[host]['ansible_facts']['napalm_lldp_neighbors'] %}
+    {%       for interface in lldp_data %}
+    {%         if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
+    "{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }}"];
+    {%         endif %}
+    {{ already_done.append( { fqdn : interface |lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
+    {%       endfor %}
+    {%     endif %}
     {% endfor %}
 }

--- a/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
+++ b/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
@@ -17,7 +17,7 @@ digraph G {
 {%       if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
     "{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }}"];
 {%       endif %}
-{{ already_done.append( { fqdn : interface |lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
+{{ already_done.append( { fqdn : interface | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
 {%     endfor %}
 {%   endif %}
 {% endfor %}

--- a/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
+++ b/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
@@ -9,16 +9,16 @@ digraph G {
     node  [style="rounded,filled,bold", shape=box, width=1.3, fontname="Arial"];
     edge [fontsize=10]; 
 {% set already_done = [] %}
-{%   for host in hostvars %}
-{%     if 'napalm_lldp_neighbors' in hostvars[host]['ansible_facts'] %}
+{% for host in hostvars %}
+{%   if 'napalm_lldp_neighbors' in hostvars[host]['ansible_facts'] %}
 {%     set fqdn = hostvars[host]['ansible_facts']['napalm_fqdn'] %}
 {%     set lldp_data = hostvars[host]['ansible_facts']['napalm_lldp_neighbors'] %}
-{%       for interface in lldp_data %}
-{%         if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
+{%     for interface in lldp_data %}
+{%       if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
     "{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }}"];
-{%         endif %}
+{%       endif %}
 {{ already_done.append( { fqdn : interface |lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
-{%       endfor %}
-{%     endif %}
+{%     endfor %}
+{%   endif %}
 {% endfor %}
 }

--- a/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
+++ b/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
@@ -14,10 +14,10 @@ digraph G {
 {%     set fqdn = hostvars[host]['ansible_facts']['napalm_fqdn'] %}
 {%     set lldp_data = hostvars[host]['ansible_facts']['napalm_lldp_neighbors'] %}
 {%     for interface in lldp_data %}
-{%       if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
-    "{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }}"];
+{%       if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<slot>^\\D\\D)\\D+(?P<portnumber>\\d.+)','\\g<slot>\\g<portnumber>')  } not in already_done %}
+    "{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<slot>^\\D\\D)\\D+(?P<portnumber>\\d.+)','\\g<slot>\\g<portnumber>') }}"];
 {%       endif %}
-{{ already_done.append( { fqdn : interface | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
+{{ already_done.append( { fqdn : interface | lower|regex_replace('(?P<slot>^\\D\\D)\\D+(?P<portnumber>\\d.+)','\\g<slot>\\g<portnumber>') }) }}
 {%     endfor %}
 {%   endif %}
 {% endfor %}

--- a/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
+++ b/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
@@ -15,7 +15,7 @@ digraph G {
 {%     set lldp_data = hostvars[host]['ansible_facts']['napalm_lldp_neighbors'] %}
 {%       for interface in lldp_data %}
 {%         if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
-"{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }}"];
+    "{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }}"];
 {%         endif %}
 {{ already_done.append( { fqdn : interface |lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
 {%       endfor %}

--- a/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
+++ b/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
@@ -8,17 +8,17 @@ digraph G {
 
     node  [style="rounded,filled,bold", shape=box, width=1.3, fontname="Arial"];
     edge [fontsize=10]; 
-    {% set already_done = [] %}
-    {%   for host in hostvars %}
-    {%     if 'napalm_lldp_neighbors' in hostvars[host]['ansible_facts'] %}
-    {%     set fqdn = hostvars[host]['ansible_facts']['napalm_fqdn'] %}
-    {%     set lldp_data = hostvars[host]['ansible_facts']['napalm_lldp_neighbors'] %}
-    {%       for interface in lldp_data %}
-    {%         if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
-    "{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }}"];
-    {%         endif %}
-    {{ already_done.append( { fqdn : interface |lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
-    {%       endfor %}
-    {%     endif %}
-    {% endfor %}
+{% set already_done = [] %}
+{%   for host in hostvars %}
+{%     if 'napalm_lldp_neighbors' in hostvars[host]['ansible_facts'] %}
+{%     set fqdn = hostvars[host]['ansible_facts']['napalm_fqdn'] %}
+{%     set lldp_data = hostvars[host]['ansible_facts']['napalm_lldp_neighbors'] %}
+{%       for interface in lldp_data %}
+{%         if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
+"{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }}"];
+{%         endif %}
+{{ already_done.append( { fqdn : interface |lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
+{%       endfor %}
+{%     endif %}
+{% endfor %}
 }

--- a/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
+++ b/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
@@ -8,17 +8,17 @@ digraph G {
 
     node  [style="rounded,filled,bold", shape=box, width=1.3, fontname="Arial"];
     edge [fontsize=10]; 
-{% set already_done = [] %}
-{% for host in hostvars %}
-{% if 'napalm_lldp_neighbors' in hostvars[host]['ansible_facts'] %}
-{% set fqdn = hostvars[host]['ansible_facts']['napalm_fqdn'] %}
-{% set lldp_data = hostvars[host]['ansible_facts']['napalm_lldp_neighbors'] %}
-{% for interface in lldp_data %}
-{% if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] } not in already_done %}
-    "{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | replace("Ethernet", "Et") }}"];
-{% endif %}
-{{ already_done.append( { fqdn : interface | replace("Ethernet", "Et") }) }}
-{% endfor %}
-{% endif %}
-{% endfor %}
+    {% set already_done = [] %}
+    {% for host in hostvars %}
+      {% if 'napalm_lldp_neighbors' in hostvars[host]['ansible_facts'] %}
+        {% set fqdn = hostvars[host]['ansible_facts']['napalm_fqdn'] %}
+        {% set lldp_data = hostvars[host]['ansible_facts']['napalm_lldp_neighbors'] %}
+          {% for interface in lldp_data %}
+            {% if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
+              "{{ fqdn }}" -- "{{ lldp_data[interface][0]['hostname'] }}";
+            {% endif %}
+            {{ already_done.append( { fqdn : interface |lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
+          {% endfor %}
+      {% endif %}
+    {% endfor %}
 }

--- a/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
+++ b/roles/cisco_lldp_topo/templates/lldp_topo.dot.j2
@@ -15,7 +15,7 @@ digraph G {
         {% set lldp_data = hostvars[host]['ansible_facts']['napalm_lldp_neighbors'] %}
           {% for interface in lldp_data %}
             {% if { lldp_data[interface][0]['hostname'] : lldp_data[interface][0]['port'] | lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>')  } not in already_done %}
-              "{{ fqdn }}" -- "{{ lldp_data[interface][0]['hostname'] }}";
+              "{{ fqdn }}" -> "{{ lldp_data[interface][0]['hostname'] }}" [minlen=2 headlabel="{{ lldp_data[interface][0]['port'] }}" taillabel="{{ interface | regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }}"];
             {% endif %}
             {{ already_done.append( { fqdn : interface |lower|regex_replace('(?P<int>^\\D\\D)\\D+(?P<slotnumber>\\d.+)','\\g<int>\\g<slotnumber>') }) }}
           {% endfor %}


### PR DESCRIPTION
Hi Erik,

Hope all is well with you, nice to see you online ;-)

I finally got around to adding your tweak to my LLDP based topology diagrams playbook.

Just for fun I added a regex to your LLDP topology jinja template to convert various (Cisco) interface names from the long format ('TenGigabitEthernet/0/1/2') to the short format ('te0/1/2') so it works both for the IOU interfaces as well as for other Cisco's. Check it out and merge if you like.

Regards, Anne